### PR TITLE
chore: bump Rails to 8.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-gem "rails", "~> 8.0.1"
+gem "rails", "~> 8.0.2"
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
 # Use sqlite3 as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,7 @@ DEPENDENCIES
   kamal
   propshaft
   puma (>= 5.0)
-  rails (~> 8.0.1)
+  rails (~> 8.0.2)
   rubocop-rails-omakase
   selenium-webdriver
   solid_cable


### PR DESCRIPTION
## Summary
- bump the Rails dependency to version 8.0.2 in the Gemfile
- align the lockfile dependency declaration with the new Rails version

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden" when hitting rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e2689c786883298cb92cb77196b7b4